### PR TITLE
Fix using lambdas in models

### DIFF
--- a/yandex_money/models.py
+++ b/yandex_money/models.py
@@ -9,6 +9,10 @@ from .signals import payment_process
 from .signals import payment_completed
 
 
+def get_default_as_uuid():
+    return str(uuid4()).replace('-', '')
+
+
 class Payment(models.Model):
     class STATUS:
         PROCESSED = 'processed'
@@ -65,7 +69,7 @@ class Payment(models.Model):
         u'Номер витрины', default=settings.YANDEX_MONEY_SCID)
     customer_number = models.CharField(
         u'Идентификатор плательщика', max_length=64,
-        default=lambda: str(uuid4()).replace('-', ''))
+        default=get_default_as_uuid)
     order_amount = models.DecimalField(
         u'Сумма заказа', max_digits=15, decimal_places=2)
 
@@ -77,7 +81,7 @@ class Payment(models.Model):
         choices=PAYMENT_TYPE.CHOICES)
     order_number = models.CharField(
         u'Номер заказа', max_length=64,
-        default=lambda: str(uuid4()).replace('-', ''))
+        default=get_default_as_uuid)
     cps_email = models.EmailField(
         u'Email плательщика', max_length=100, blank=True, null=True)
     cps_phone = models.CharField(


### PR DESCRIPTION
В новых версиях Django, начиная с 1.7, нельзя использовать lambda-функции в качестве default параметра, так как lambda не может быть сериализована для миграций (см. http://djbook.ru/rel1.8/topics/migrations.html#serializing-values). Данный pull-request исправляет эту ошибку.
