### PR TITLE
fix paymentPayerCode required only for Yandex Money

### DIFF
--- a/yandex_money/forms.py
+++ b/yandex_money/forms.py
@@ -158,7 +158,7 @@ class CheckForm(BasePaymentForm):
     orderSumCurrencyPaycash = forms.IntegerField()
     shopSumAmount = forms.DecimalField(min_value=0, decimal_places=2)
     shopSumCurrencyPaycash = forms.IntegerField()
-    paymentPayerCode = forms.IntegerField(min_value=1)
+    paymentPayerCode = forms.IntegerField(min_value=1, required=False)
 
 
 class NoticeForm(BasePaymentForm):
@@ -167,6 +167,6 @@ class NoticeForm(BasePaymentForm):
     orderSumCurrencyPaycash = forms.IntegerField()
     shopSumAmount = forms.DecimalField(min_value=0, decimal_places=2)
     shopSumCurrencyPaycash = forms.IntegerField()
-    paymentPayerCode = forms.IntegerField(min_value=1)
+    paymentPayerCode = forms.IntegerField(min_value=1, required=False)
     cps_email = forms.EmailField(required=False)
     cps_phone = forms.CharField(max_length=15, required=False)

--- a/yandex_money/views.py
+++ b/yandex_money/views.py
@@ -142,7 +142,7 @@ class NoticeFormView(BaseView):
         payment.order_currency = cd.get('orderSumCurrencyPaycash')
         payment.shop_amount = cd.get('shopSumAmount')
         payment.shop_currency = cd.get('shopSumCurrencyPaycash')
-        payment.payer_code = cd.get('paymentPayerCode')
+        payment.payer_code = cd.get('paymentPayerCode', '')
         payment.payment_type = cd.get('paymentType')
         payment.status = payment.STATUS.SUCCESS
         payment.save()


### PR DESCRIPTION
Яндекс Касса перестала посылать paymentPayerCode для всех типов платежей (кроме, видимо, Яндекс Денег)
А поле было обязательным в форме, из-за этого проверка платежа не проходила.
