### PR TITLE
Use timezone-aware date for performed_datetime

### DIFF
--- a/yandex_money/views.py
+++ b/yandex_money/views.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from datetime import datetime
 
 from django.http import HttpResponse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
@@ -84,7 +84,7 @@ class BaseView(View):
 
     def get_response_params(self, payment, cd):
         if payment:
-            now = datetime.now()
+            now = timezone.now()
 
             payment.performed_datetime = now
             payment.save()


### PR DESCRIPTION
Сделал, чтобы в поле `performed_datetime` сохранялась [timezone-aware](https://docs.djangoproject.com/en/1.9/topics/i18n/timezones/#naive-and-aware-datetime-objects) дата для сайтов с поддержкой часовых поясов (где `USE_TZ=True`).
