### PR TITLE
Добавил поддержку Django 2.0

### DIFF
--- a/example/app/models.py
+++ b/example/app/models.py
@@ -18,10 +18,11 @@ class Goods(models.Model):
 
 
 class Order(models.Model):
-    goods = models.ForeignKey(Goods, verbose_name='Товар')
+    goods = models.ForeignKey(Goods, verbose_name='Товар', on_delete=models.CASCADE)
     count = models.PositiveIntegerField('Кол-во', default=1)
     payment = models.ForeignKey('yandex_money.Payment',
-                                verbose_name='Платеж')
+                                verbose_name='Платеж',
+                                on_delete=models.CASCADE)
     amount = models.PositiveIntegerField('Сумма заказа')
 
     class Meta:

--- a/yandex_money/models.py
+++ b/yandex_money/models.py
@@ -67,7 +67,7 @@ class Payment(models.Model):
 
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, blank=True, null=True,
-        verbose_name='Пользователь')
+        verbose_name='Пользователь', on_delete=models.CASCADE)
     pub_date = models.DateTimeField('Время создания', auto_now_add=True)
 
     # Required request fields


### PR DESCRIPTION
"The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations."
Django 2.0 release notes https://docs.djangoproject.com/en/2.0/releases/2.0/
Ранее, если в модели не указан аргумент "on_delete", по умолчанию работало "CASCADE" (можно проверить в файле миграции). Явно указал "CASCADE" в моделях, иначе ругается при запуске, что не хватает обязательного аргумента.